### PR TITLE
Expose TermID

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use index::ColumnIndex;
 use instant::{Duration, Instant};
 pub use serialize::SerializeConfig;
 use sort::*;
-pub use termdag::{Term, TermDag};
+pub use termdag::{Term, TermDag, TermId};
 use thiserror::Error;
 
 use proofs::ProofState;


### PR DESCRIPTION
Follow up from https://github.com/egraphs-good/egglog/pull/202 to expose the TermID so that we can create/access them in the Python bindings.